### PR TITLE
Fix: Resolve the doom-themes dependency explicitly

### DIFF
--- a/doom-nano-dark-theme.el
+++ b/doom-nano-dark-theme.el
@@ -41,6 +41,8 @@
 
 ;;; Code:
 
+(require 'doom-themes)
+
 (defgroup doom-nano-dark-theme nil
   "Options for the `doom-nano-dark' theme."
   :group 'doom-themes)


### PR DESCRIPTION
Should fix an issue where the theme fails to load when set as the initial theme, e.g. via `(setq doom-theme ...)`.