### PR TITLE
Resolve doom-themes dependency explicitly (light-theme)

### DIFF
--- a/doom-nano-light-theme.el
+++ b/doom-nano-light-theme.el
@@ -41,6 +41,8 @@
 
 ;;; Code:
 
+(require 'doom-themes)
+
 (defgroup doom-nano-light-theme nil
   "Options for the `doom-nano-light' theme."
   :group 'doom-themes)


### PR DESCRIPTION
#9 only fixed the issue for the dark theme - this is the same fix for the light theme.